### PR TITLE
Fix scoreboard box borders not matching content width

### DIFF
--- a/tictactoe.py
+++ b/tictactoe.py
@@ -41,10 +41,18 @@ def display_scoreboard(names, scores):
 
     Uses f-strings - a way to put variables inside a string
     by writing f"text {variable} more text".
+
+    The box width adjusts dynamically based on the content length
+    so the top and bottom borders always match.
     """
-    print(f"  ┌─── SCOREBOARD ───┐")
-    print(f"  │ {names['X']}: {scores['X']}  vs  {names['O']}: {scores['O']}  │  Ties: {scores['tie']}")
-    print(f"  └────────────────────┘")
+    # Build the content line first so we can measure its length
+    content = f" {names['X']}: {scores['X']}  vs  {names['O']}: {scores['O']}  Ties: {scores['tie']} "
+    # Calculate how wide the box needs to be
+    width = len(content)
+    # Build the box with matching borders
+    print("  ┌" + "─" * width + "┐")
+    print("  │" + content + "│")
+    print("  └" + "─" * width + "┘")
 
 
 def get_player_names():


### PR DESCRIPTION
## Summary
- Calculate content width dynamically instead of using hardcoded border lengths
- Top and bottom borders now resize to match the content line exactly
- Works correctly with any player name length or score digit count

Fixes #18

## Before
```
  ┌─── SCOREBOARD ───┐
  │ Alice: 1  vs  Bob: 0  │  Ties: 0
  └────────────────────┘
```

## After
```
  ┌───────────────────────────────┐
  │ Alice: 1  vs  Bob: 0  Ties: 0 │
  └───────────────────────────────┘
```

## Test plan
- [x] Short names (2 chars) — borders align
- [x] Medium names (3-5 chars) — borders align
- [x] Long names (9+ chars) — borders align
- [x] Multi-digit scores — borders align

🤖 Generated with [Claude Code](https://claude.com/claude-code)