### PR TITLE
Add Claude Code files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ venv/
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code
+CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` and `.claude/` to `.gitignore` to keep local Claude Code configuration out of the public repository

## Test plan
- [x] Verify CLAUDE.md and .claude/ directory are excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)